### PR TITLE
Update CdkDotnet.csproj

### DIFF
--- a/cdk-dotnet/src/CdkDotnet/CdkDotnet.csproj
+++ b/cdk-dotnet/src/CdkDotnet/CdkDotnet.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.93.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.130.0" />
     <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props


### PR DESCRIPTION
the package, Amazon.CDK.Lib 2.93.0,  has python 3.7 which version has been deprecated in lambda runtime. need upgrade to 2.130.0.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
